### PR TITLE
Setup Lambda@Edge

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,53 +7,53 @@ module "homepage" {
   origin_response_arn = module.lambda.origin_response_arn
   viewer_request_arn  = module.lambda.viewer_request_arn
   providers = {
-    aws = aws
-    aws.cert = aws.cert
+    aws        = aws
+    aws.cert   = aws.cert
     cloudflare = cloudflare
   }
 }
 
 module "install" {
-  source          = "./modules/ractf/modules/frontend"
-  deployment_name = "install"
-  deploy_account  = var.deploy_account
-  root_domain     = var.root_domain
-  zone            = module.dns.zone
+  source              = "./modules/ractf/modules/frontend"
+  deployment_name     = "install"
+  deploy_account      = var.deploy_account
+  root_domain         = var.root_domain
+  zone                = module.dns.zone
   origin_response_arn = module.lambda.origin_response_arn
   viewer_request_arn  = module.lambda.viewer_request_arn
   providers = {
-    aws = aws
-    aws.cert = aws.cert
+    aws        = aws
+    aws.cert   = aws.cert
     cloudflare = cloudflare
   }
 }
 
 module "docs" {
-  source          = "./modules/ractf/modules/frontend"
-  deployment_name = "docs"
-  deploy_account  = var.deploy_account
-  root_domain     = var.root_domain
-  zone            = module.dns.zone
+  source              = "./modules/ractf/modules/frontend"
+  deployment_name     = "docs"
+  deploy_account      = var.deploy_account
+  root_domain         = var.root_domain
+  zone                = module.dns.zone
   origin_response_arn = module.lambda.origin_response_arn
   viewer_request_arn  = module.lambda.viewer_request_arn
   providers = {
-    aws = aws
-    aws.cert = aws.cert
+    aws        = aws
+    aws.cert   = aws.cert
     cloudflare = cloudflare
   }
 }
 
 module "bentestbucket" {
-  source          = "./modules/ractf/modules/frontend"
-  deployment_name = "bentestbucket"
-  deploy_account  = aws_iam_user.bentestuser.arn
-  root_domain     = var.root_domain
-  zone            = module.dns.zone
+  source              = "./modules/ractf/modules/frontend"
+  deployment_name     = "bentestbucket"
+  deploy_account      = aws_iam_user.bentestuser.arn
+  root_domain         = var.root_domain
+  zone                = module.dns.zone
   origin_response_arn = module.lambda.origin_response_arn
   viewer_request_arn  = module.lambda.viewer_request_arn
   providers = {
-    aws = aws
-    aws.cert = aws.cert
+    aws        = aws
+    aws.cert   = aws.cert
     cloudflare = cloudflare
   }
 }
@@ -64,46 +64,46 @@ resource "aws_iam_user" "bentestuser" {
 }
 
 module "keygen" {
-  source          = "./modules/ractf/modules/frontend"
-  deployment_name = "keygen"
-  deploy_account  = var.deploy_account
-  root_domain     = var.root_domain
-  zone            = module.dns.zone
+  source              = "./modules/ractf/modules/frontend"
+  deployment_name     = "keygen"
+  deploy_account      = var.deploy_account
+  root_domain         = var.root_domain
+  zone                = module.dns.zone
   origin_response_arn = module.lambda.origin_response_arn
   viewer_request_arn  = module.lambda.viewer_request_arn
   providers = {
-    aws = aws
-    aws.cert = aws.cert
+    aws        = aws
+    aws.cert   = aws.cert
     cloudflare = cloudflare
   }
 }
 
 module "cloud_homepage" {
-  source          = "./modules/ractf/modules/frontend"
-  deployment_name = "www"
-  deploy_account  = var.deploy_account
-  root_domain     = var.cloud_domain
-  zone            = module.cloud_dns.zone
+  source              = "./modules/ractf/modules/frontend"
+  deployment_name     = "www"
+  deploy_account      = var.deploy_account
+  root_domain         = var.cloud_domain
+  zone                = module.cloud_dns.zone
   origin_response_arn = module.lambda.origin_response_arn
   viewer_request_arn  = module.lambda.viewer_request_arn
   providers = {
-    aws = aws
-    aws.cert = aws.cert
+    aws        = aws
+    aws.cert   = aws.cert
     cloudflare = cloudflare
   }
 }
 
 module "cloud_wildcard" {
-  source          = "./modules/ractf/modules/frontend"
-  deployment_name = "*"
-  deploy_account  = var.deploy_account
-  root_domain     = var.cloud_domain
-  zone            = module.cloud_dns.zone
+  source              = "./modules/ractf/modules/frontend"
+  deployment_name     = "*"
+  deploy_account      = var.deploy_account
+  root_domain         = var.cloud_domain
+  zone                = module.cloud_dns.zone
   origin_response_arn = module.lambda.origin_response_arn
   viewer_request_arn  = module.lambda.viewer_request_arn
   providers = {
-    aws = aws
-    aws.cert = aws.cert
+    aws        = aws
+    aws.cert   = aws.cert
     cloudflare = cloudflare
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,12 @@
 module "homepage" {
-  source          = "./modules/ractf/modules/frontend"
-  deployment_name = "www"
-  deploy_account  = var.deploy_account
-  root_domain     = var.root_domain
-  zone            = module.dns.zone
-    providers = {
+  source              = "./modules/ractf/modules/frontend"
+  deployment_name     = "www"
+  deploy_account      = var.deploy_account
+  root_domain         = var.root_domain
+  zone                = module.dns.zone
+  origin_response_arn = module.lambda.origin_response_arn
+  viewer_request_arn  = module.lambda.viewer_request_arn
+  providers = {
     aws = aws
     aws.cert = aws.cert
     cloudflare = cloudflare
@@ -17,6 +19,8 @@ module "install" {
   deploy_account  = var.deploy_account
   root_domain     = var.root_domain
   zone            = module.dns.zone
+  origin_response_arn = module.lambda.origin_response_arn
+  viewer_request_arn  = module.lambda.viewer_request_arn
   providers = {
     aws = aws
     aws.cert = aws.cert
@@ -30,6 +34,8 @@ module "docs" {
   deploy_account  = var.deploy_account
   root_domain     = var.root_domain
   zone            = module.dns.zone
+  origin_response_arn = module.lambda.origin_response_arn
+  viewer_request_arn  = module.lambda.viewer_request_arn
   providers = {
     aws = aws
     aws.cert = aws.cert
@@ -43,6 +49,8 @@ module "bentestbucket" {
   deploy_account  = aws_iam_user.bentestuser.arn
   root_domain     = var.root_domain
   zone            = module.dns.zone
+  origin_response_arn = module.lambda.origin_response_arn
+  viewer_request_arn  = module.lambda.viewer_request_arn
   providers = {
     aws = aws
     aws.cert = aws.cert
@@ -61,6 +69,8 @@ module "keygen" {
   deploy_account  = var.deploy_account
   root_domain     = var.root_domain
   zone            = module.dns.zone
+  origin_response_arn = module.lambda.origin_response_arn
+  viewer_request_arn  = module.lambda.viewer_request_arn
   providers = {
     aws = aws
     aws.cert = aws.cert
@@ -74,6 +84,8 @@ module "cloud_homepage" {
   deploy_account  = var.deploy_account
   root_domain     = var.cloud_domain
   zone            = module.cloud_dns.zone
+  origin_response_arn = module.lambda.origin_response_arn
+  viewer_request_arn  = module.lambda.viewer_request_arn
   providers = {
     aws = aws
     aws.cert = aws.cert
@@ -87,6 +99,8 @@ module "cloud_wildcard" {
   deploy_account  = var.deploy_account
   root_domain     = var.cloud_domain
   zone            = module.cloud_dns.zone
+  origin_response_arn = module.lambda.origin_response_arn
+  viewer_request_arn  = module.lambda.viewer_request_arn
   providers = {
     aws = aws
     aws.cert = aws.cert
@@ -105,6 +119,8 @@ module "deployment" {
   container_registry  = each.value.container_registry
   backend_account     = module.ses.backend_account
   new_relic_policy_id = module.newrelic.policy_id
+  origin_response_arn = module.lambda.origin_response_arn
+  viewer_request_arn  = module.lambda.viewer_request_arn
   providers = {
     aws        = aws
     aws.cert   = aws.cert
@@ -178,4 +194,8 @@ module "consul" {
 module "newrelic" {
   source      = "./modules/support/newrelic"
   discord_url = var.discord_url
+}
+
+module "lambda" {
+  source = "./modules/support/lambda"
 }

--- a/modules/ractf/inputs.tf
+++ b/modules/ractf/inputs.tf
@@ -39,3 +39,13 @@ variable "new_relic_policy_id" {
   type        = string
   description = "New Relic Policy ID for Alerting"
 }
+
+variable "origin-response-arn" {
+  type        = string
+  description = "ARN of the Origin Response Lambda"
+}
+
+variable "viewer-request-arn" {
+  type        = string
+  description = "ARN of the Viewer Request Lambda"
+}

--- a/modules/ractf/inputs.tf
+++ b/modules/ractf/inputs.tf
@@ -40,12 +40,12 @@ variable "new_relic_policy_id" {
   description = "New Relic Policy ID for Alerting"
 }
 
-variable "origin-response-arn" {
+variable "origin_response_arn" {
   type        = string
   description = "ARN of the Origin Response Lambda"
 }
 
-variable "viewer-request-arn" {
+variable "viewer_request_arn" {
   type        = string
   description = "ARN of the Viewer Request Lambda"
 }

--- a/modules/ractf/main.tf
+++ b/modules/ractf/main.tf
@@ -1,9 +1,11 @@
 module "frontend" {
-  source          = "./modules/frontend"
-  root_domain     = var.root_domain
-  deployment_name = var.deployment_name
-  deploy_account  = var.deploy_account
-  zone            = var.zone
+  source              = "./modules/frontend"
+  root_domain         = var.root_domain
+  deployment_name     = var.deployment_name
+  deploy_account      = var.deploy_account
+  zone                = var.zone
+  origin_response_arn = module.lambda.origin_response_arn
+  viewer_request_arn  = module.lambda.viewer_request_arn
   providers = {
     aws        = aws
     aws.cert   = aws.cert

--- a/modules/ractf/main.tf
+++ b/modules/ractf/main.tf
@@ -4,8 +4,8 @@ module "frontend" {
   deployment_name     = var.deployment_name
   deploy_account      = var.deploy_account
   zone                = var.zone
-  origin_response_arn = module.lambda.origin_response_arn
-  viewer_request_arn  = module.lambda.viewer_request_arn
+  origin_response_arn = var.origin_response_arn
+  viewer_request_arn  = var.viewer_request_arn
   providers = {
     aws        = aws
     aws.cert   = aws.cert

--- a/modules/ractf/modules/backend/main.tf
+++ b/modules/ractf/modules/backend/main.tf
@@ -20,7 +20,7 @@ resource "newrelic_synthetics_monitor" "stats" {
 }
 
 resource "newrelic_synthetics_alert_condition" "stats" {
-  policy_id   = var.new_relic_policy_id
-  name        = "${var.deployment_name} Alert Condition"
-  monitor_id  = newrelic_synthetics_monitor.stats.id
+  policy_id  = var.new_relic_policy_id
+  name       = "${var.deployment_name} Alert Condition"
+  monitor_id = newrelic_synthetics_monitor.stats.id
 }

--- a/modules/ractf/modules/frontend/inputs.tf
+++ b/modules/ractf/modules/frontend/inputs.tf
@@ -17,3 +17,9 @@ variable "zone" {
   type        = string
   description = "The Cloudflare Zone ID"
 }
+
+variable "indexflatten" {
+  type    = bool
+  description = "Apply a Lambda add index.html"
+  default = false
+}

--- a/modules/ractf/modules/frontend/inputs.tf
+++ b/modules/ractf/modules/frontend/inputs.tf
@@ -19,7 +19,17 @@ variable "zone" {
 }
 
 variable "indexflatten" {
-  type    = bool
+  type        = bool
   description = "Apply a Lambda add index.html"
-  default = false
+  default     = false
+}
+
+variable "origin-response-arn" {
+  type        = string
+  description = "ARN of the Origin Response Lambda"
+}
+
+variable "viewer-request-arn" {
+  type        = string
+  description = "ARN of the Viewer Request Lambda"
 }

--- a/modules/ractf/modules/frontend/inputs.tf
+++ b/modules/ractf/modules/frontend/inputs.tf
@@ -24,12 +24,12 @@ variable "indexflatten" {
   default     = false
 }
 
-variable "origin-response-arn" {
+variable "origin_response_arn" {
   type        = string
   description = "ARN of the Origin Response Lambda"
 }
 
-variable "viewer-request-arn" {
+variable "viewer_request_arn" {
   type        = string
   description = "ARN of the Viewer Request Lambda"
 }

--- a/modules/ractf/modules/frontend/main.tf
+++ b/modules/ractf/modules/frontend/main.tf
@@ -50,7 +50,7 @@ resource "aws_s3_bucket" "frontend_bucket" {
 }
 
 locals {
-  s3_origin_id = "frontendS3Origin"
+  s3_origin_id           = "frontendS3Origin"
   viewer_request_lambda  = "viewer_request_lambda"
   origin_response_lambda = "origin_response_lambda"
 }
@@ -94,13 +94,13 @@ resource "aws_cloudfront_distribution" "frontend_distribution" {
     lambda_function_association {
       event_type   = "origin-response"
       lambda_arn   = var.origin_response_arn
-      include_body = false 
+      include_body = false
     }
 
     lambda_function_association {
       event_type   = "viewer-request"
       lambda_arn   = var.viewer_request_arn
-      include_body = false 
+      include_body = false
     }
   }
 

--- a/modules/ractf/modules/frontend/main.tf
+++ b/modules/ractf/modules/frontend/main.tf
@@ -51,6 +51,8 @@ resource "aws_s3_bucket" "frontend_bucket" {
 
 locals {
   s3_origin_id = "frontendS3Origin"
+  viewer_request_lambda  = "viewer_request_lambda"
+  origin_response_lambda = "origin_response_lambda"
 }
 
 resource "aws_cloudfront_distribution" "frontend_distribution" {

--- a/modules/ractf/modules/frontend/main.tf
+++ b/modules/ractf/modules/frontend/main.tf
@@ -90,6 +90,18 @@ resource "aws_cloudfront_distribution" "frontend_distribution" {
     default_ttl            = 3600
     max_ttl                = 86400
     compress               = true
+
+    lambda_function_association {
+      event_type   = "origin-response"
+      lambda_arn   = var.origin_response_arn
+      include_body = false 
+    }
+
+    lambda_function_association {
+      event_type   = "viewer-request"
+      lambda_arn   = var.viewer_request_arn
+      include_body = false 
+    }
   }
 
   restrictions {

--- a/modules/ractf/modules/static/main.tf
+++ b/modules/ractf/modules/static/main.tf
@@ -33,9 +33,9 @@ data "aws_iam_policy_document" "static_files" {
   }
 
   statement {
-    sid       = "BackendAllow"
-    effect    = "Allow"
-    actions   = [
+    sid    = "BackendAllow"
+    effect = "Allow"
+    actions = [
       "s3:GetObject",
       "s3:PutObject",
       "s3:PutObjectAcl",

--- a/modules/ractf/versions.tf
+++ b/modules/ractf/versions.tf
@@ -8,7 +8,7 @@ terraform {
       version = "2.9.0"
     }
     newrelic = {
-      source = "newrelic/newrelic"
+      source  = "newrelic/newrelic"
       version = "2.14.0"
     }
   }

--- a/modules/support/consul/main.tf
+++ b/modules/support/consul/main.tf
@@ -17,7 +17,7 @@ resource "consul_config_entry" "production_gateway" {
       Enabled = false
     }
 
-    Listeners  = [{
+    Listeners = [{
       Port     = 80
       Protocol = "tcp"
       Services = [{
@@ -56,5 +56,5 @@ resource "consul_acl_policy" "production_gateway" {
 
 resource "consul_acl_token" "production_gateway" {
   description = "Consul Connect gateway"
-  policies = [consul_acl_policy.production_gateway.name]
+  policies    = [consul_acl_policy.production_gateway.name]
 }

--- a/modules/support/lambda/README.md
+++ b/modules/support/lambda/README.md
@@ -1,0 +1,5 @@
+# Lambda@Edge
+
+This module deploys some Lambda scripts which can be used by frontends.
+
+This is heavily based on <https://github.com/mbacchi/lambda-edge-cloudfront-terraform>.

--- a/modules/support/lambda/main.tf
+++ b/modules/support/lambda/main.tf
@@ -9,13 +9,13 @@ resource "aws_iam_role" "lambda_role" {
 
 data "aws_iam_policy_document" "lambda_role" {
   statement {
-      sid = "cloudfront_role"
+    sid = "cloudfront_role"
 
-      actions = [ "sts:AssumeRole" ]
-      principals {
-        type = "Service"
-        identifiers = [ "lambda.amazonaws.com", "edgelambda.amazonaws.com" ]
-      }
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com", "edgelambda.amazonaws.com"]
+    }
   }
 }
 
@@ -33,9 +33,9 @@ resource "aws_iam_policy" "lambda_logging" {
 
 data "aws_iam_policy_document" "lambda_logging" {
   statement {
-    sid = "lambda_logging"
-    actions = [ "logs:CreateLogGroup", "logs:Cre3ateLogStream", "logs:PutLogEvents" ]
-    resources = [ "arn:aws:logs:*:*:*" ] # TODO
+    sid       = "lambda_logging"
+    actions   = ["logs:CreateLogGroup", "logs:Cre3ateLogStream", "logs:PutLogEvents"]
+    resources = ["arn:aws:logs:*:*:*"] # TODO
   }
 }
 

--- a/modules/support/lambda/main.tf
+++ b/modules/support/lambda/main.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 resource "aws_iam_role" "lambda_role" {
-  assume_role_policy = aws_iam_policy_document.lambda_role.json
+  assume_role_policy = data.aws_iam_policy_document.lambda_role.json
 }
 
 data "aws_iam_policy_document" "lambda_role" {
@@ -28,7 +28,7 @@ resource "aws_iam_policy" "lambda_logging" {
   path        = "/"
   description = "IAM policy for logging from a lambda"
 
-  policy = aws_iam_policy_document.lambda_logging.json
+  policy = data.aws_iam_policy_document.lambda_logging.json
 }
 
 data "aws_iam_policy_document" "lambda_logging" {

--- a/modules/support/lambda/main.tf
+++ b/modules/support/lambda/main.tf
@@ -1,0 +1,85 @@
+locals {
+  viewer_request_lambda  = "viewer_request_lambda"
+  origin_response_lambda = "origin_response_lambda"
+}
+
+resource "aws_iam_role" "lambda_role" {
+  assume_role_policy = aws_iam_policy_document.lambda_role.json
+}
+
+data "aws_iam_policy_document" "lambda_role" {
+  statement {
+      sid = "cloudfront_role"
+
+      actions = [ "sts:AssumeRole" ]
+      principals {
+        type = "Service"
+        identifiers = [ "lambda.amazonaws.com", "edgelambda.amazonaws.com" ]
+      }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "terraform_lambda_edge_python_log_group" {
+  name              = "/aws/lambda/eu-west-2.terraform_lambda_edge_python"
+  retention_in_days = 2
+}
+
+resource "aws_iam_policy" "lambda_logging" {
+  path        = "/"
+  description = "IAM policy for logging from a lambda"
+
+  policy = aws_iam_policy_document.lambda_logging.json
+}
+
+data "aws_iam_policy_document" "lambda_logging" {
+  statement {
+    sid = "lambda_logging"
+    actions = [ "logs:CreateLogGroup", "logs:Cre3ateLogStream", "logs:PutLogEvents" ]
+    resources = [ "arn:aws:logs:*:*:*" ] # TODO
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_logs" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = aws_iam_policy.lambda_logging.arn
+}
+
+data "archive_file" "origin_response_lambda" {
+  type        = "zip"
+  source_file = "./scripts/originresponse.js"
+  output_path = "origin_response_lambda.zip"
+}
+
+resource "aws_lambda_function" "origin_response_lambda" {
+  depends_on    = [aws_iam_role_policy_attachment.lambda_logs]
+  filename      = data.archive_file.origin_response_lambda.output_path
+  function_name = local.origin_response_lambda
+  role          = aws_iam_role.lambda_role.arn
+  handler       = "origin_response.handler"
+
+  source_code_hash = filebase64sha256(data.archive_file.origin_response_lambda.output_path)
+
+  runtime = "nodejs12.x"
+
+  publish = true
+}
+
+data "archive_file" "viewer_request_lambda" {
+  type        = "zip"
+  source_file = "./scripts/viewerrequest.js"
+  output_path = "viewer_request_lambda.zip"
+}
+
+resource "aws_lambda_function" "viewer_request_lambda" {
+  depends_on    = [aws_iam_role_policy_attachment.lambda_logs]
+  filename      = data.archive_file.viewer_request_lambda.output_path
+  function_name = local.viewer_request_lambda
+  role          = aws_iam_role.lambda_role.arn
+  handler       = "viewer_request.handler"
+
+  source_code_hash = filebase64sha256(data.archive_file.viewer_request_lambda.output_path)
+
+  runtime = "nodejs12.x"
+
+  publish = true
+}

--- a/modules/support/lambda/main.tf
+++ b/modules/support/lambda/main.tf
@@ -46,7 +46,7 @@ resource "aws_iam_role_policy_attachment" "lambda_logs" {
 
 data "archive_file" "origin_response_lambda" {
   type        = "zip"
-  source_file = "./scripts/originresponse.js"
+  source_file = "${path.module}/scripts/originresponse.js"
   output_path = "origin_response_lambda.zip"
 }
 
@@ -66,7 +66,7 @@ resource "aws_lambda_function" "origin_response_lambda" {
 
 data "archive_file" "viewer_request_lambda" {
   type        = "zip"
-  source_file = "./scripts/viewerrequest.js"
+  source_file = "${path.module}/scripts/viewerrequest.js"
   output_path = "viewer_request_lambda.zip"
 }
 

--- a/modules/support/lambda/outputs.tf
+++ b/modules/support/lambda/outputs.tf
@@ -1,0 +1,7 @@
+output "origin_response_arn" {
+  value = aws_lambda_function.origin_response_lambda.qualified_arn
+}
+
+output "viewer_request_arn" {
+  value = aws_lambda_function.viewer_request_lambda.qualified_arn
+}

--- a/modules/support/lambda/scripts/originresponse.js
+++ b/modules/support/lambda/scripts/originresponse.js
@@ -1,0 +1,5 @@
+'use strict';
+exports.handler = (event, context, callback) => {
+    request.uri = event.Records[0].cf.request.uri.replace(/\/$/, '\/index.html');
+    return callback(null, request);
+};

--- a/modules/support/lambda/scripts/viewerrequest.js
+++ b/modules/support/lambda/scripts/viewerrequest.js
@@ -1,0 +1,36 @@
+'use strict';
+exports.handler = (event, context, callback) => {
+
+    //Get contents of response
+    const response = event.Records[0].cf.response;
+    const headers = response.headers;
+
+    //Set new headers 
+    headers['strict-transport-security'] = [{
+        key: 'Strict-Transport-Security',
+        value: 'max-age=63072000; includeSubdomains; preload'
+    }];
+    headers['content-security-policy'] = [{
+        key: 'Content-Security-Policy',
+        value: "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'"
+    }];
+    headers['x-content-type-options'] = [{
+        key: 'X-Content-Type-Options',
+        value: 'nosniff'
+    }];
+    headers['x-frame-options'] = [{
+        key: 'X-Frame-Options',
+        value: 'DENY'
+    }];
+    headers['x-xss-protection'] = [{
+        key: 'X-XSS-Protection',
+        value: '1; mode=block'
+    }];
+    headers['referrer-policy'] = [{
+        key: 'Referrer-Policy',
+        value: 'same-origin'
+    }];
+
+    //Return modified response
+    callback(null, response);
+};

--- a/modules/support/newrelic/main.tf
+++ b/modules/support/newrelic/main.tf
@@ -8,7 +8,7 @@ resource "newrelic_alert_channel" "discord" {
 }
 
 resource "newrelic_alert_policy_channel" "channel" {
-  policy_id  = newrelic_alert_policy.policy.id
+  policy_id = newrelic_alert_policy.policy.id
   channel_ids = [
     newrelic_alert_channel.discord.id
   ]
@@ -21,8 +21,8 @@ resource "newrelic_alert_policy" "policy" {
 resource "newrelic_infra_alert_condition" "host_not_reporting" {
   policy_id = newrelic_alert_policy.policy.id
 
-  name       = "Host not reporting"
-  type       = "infra_host_not_reporting"
+  name = "Host not reporting"
+  type = "infra_host_not_reporting"
 
   critical {
     duration = 5

--- a/modules/support/ses/outputs.tf
+++ b/modules/support/ses/outputs.tf
@@ -1,3 +1,3 @@
 output "backend_account" {
-    value = aws_iam_user.backend_ses.arn
+  value = aws_iam_user.backend_ses.arn
 }

--- a/providers.tf
+++ b/providers.tf
@@ -33,3 +33,5 @@ provider "newrelic" {
   api_key    = var.new_relic_key
   region     = "EU"
 }
+
+provider "archive" {}

--- a/providers.tf
+++ b/providers.tf
@@ -16,11 +16,11 @@ provider "cloudflare" {
 }
 
 provider "consul" {
-  address    = var.consul_address
-  http_auth  = var.consul_auth
-  token      = var.consul_token
-  cert_pem   = var.consul_cert
-  key_pem    = var.consul_key
+  address   = var.consul_address
+  http_auth = var.consul_auth
+  token     = var.consul_token
+  cert_pem  = var.consul_cert
+  key_pem   = var.consul_key
 }
 
 provider "nomad" {

--- a/versions.tf
+++ b/versions.tf
@@ -27,5 +27,9 @@ terraform {
       source  = "newrelic/newrelic"
       version = "2.14.0"
     }
+    archive = {
+      source = "hashicorp/archive"
+      version = "2.0.0"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -16,15 +16,15 @@ terraform {
       version = "2.9.0"
     }
     consul = {
-      source = "hashicorp/consul"
+      source  = "hashicorp/consul"
       version = "2.10.1"
     }
     nomad = {
-      source = "hashicorp/nomad"
+      source  = "hashicorp/nomad"
       version = "1.4.11"
     }
     newrelic = {
-      source = "newrelic/newrelic"
+      source  = "newrelic/newrelic"
       version = "2.14.0"
     }
   }


### PR DESCRIPTION
Resolves #5 and hopefully a variety of @Bottersnike's ongoing complaints.

The scripts in here are based on <https://aws.amazon.com/blogs/networking-and-content-delivery/adding-http-security-headers-using-lambdaedge-and-amazon-cloudfront/> and <https://aws.amazon.com/blogs/compute/implementing-default-directory-indexes-in-amazon-s3-backed-amazon-cloudfront-origins-using-lambdaedge/>, so they should hopefully work. They're running under Node 12.x, if that's useful for working out if they'll work.

@Bottersnike Also needs to look over the headers in `origin-response.js` to make sure they'll work with ractf/shell.