### PR TITLE
More cleanly handle the wildcard

### DIFF
--- a/modules/ractf/modules/frontend/main.tf
+++ b/modules/ractf/modules/frontend/main.tf
@@ -58,8 +58,8 @@ locals {
 }
 
 resource "aws_cloudfront_cache_policy" "cache_policy" {
-  name        = "ractf-${var.deployment_name}-policy"
-  comment     = "Policy for ${var.deployment_name}.${var.root_domain}"
+  name        = "ractf-production-${local.nice_deployment_name}-policy"
+  comment     = "Policy for ${local.nice_deployment_name}.${var.root_domain}"
   default_ttl = 86400
   max_ttl     = 604800
   min_ttl     = 1


### PR DESCRIPTION
This will still error, but should less so

The crash is due to hashicorp/terraform-provider-aws#17626 going to try and fix manually